### PR TITLE
Change port from 9001 to 9104 by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM       alpine:latest
-MAINTAINER David Cuadrado <dacuad@facebook.com>
-EXPOSE     9001
+MAINTAINER Tim Vaillancourt <tim.vaillancourt@percona.com>
+EXPOSE     9104
 
 ENV  GOPATH /go
 ENV APPPATH $GOPATH/src/github.com/Percona-Lab/prometheus_mongodb_exporter

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 David Cuadrado
+Copyright (c) 2016 Percona
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It is recommended to define the following options:
 - **-mongodb.uri** - The URI of the MongoDB port (*default: mongodb://localhost:27017*)
 - **-auth.user** - The optional auth username (*default: none*)
 - **-auth.pass** - The optional auth password (*default: none*)
-- **-web.listen-address** - The listen address of the exporter (*default: ":9001"*)
+- **-web.listen-address** - The listen address of the exporter (*default: ":9104"*)
 - **-log_dir** - The directory to write the log file (*default: /tmp*)
 
 *For more options see the help page with '-h' or '--help'*

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -20,7 +20,7 @@ func mongodbDefaultUri() string {
 }
 
 var (
-	listenAddressFlag = flag.String("web.listen-address", ":9001", "Address on which to expose metrics and web interface.")
+	listenAddressFlag = flag.String("web.listen-address", ":9104", "Address on which to expose metrics and web interface.")
 	metricsPathFlag   = flag.String("web.metrics-path", "/metrics", "Path under which to expose metrics.")
 
 	mongodbURIFlag    = flag.String("mongodb.uri", mongodbDefaultUri(), "Mongodb URI, format: [mongodb://][user:pass@]host1[:port1][,host2[:port2],...][/database][?options]")


### PR DESCRIPTION
This is so the mysql and mongo exporters run on the same port by default. It can be changed in the configuration but  this simplifies things in other systems.