### PR TITLE
Adding -version flag to mongodb_exporter.go

### DIFF
--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -40,6 +40,8 @@
 VERSION ?= $(error VERSION not set in including Makefile)
 TARGET  ?= $(error TARGET not set in including Makefile)
 
+GIT_COMMIT := $(shell git rev-parse HEAD)
+
 SRC    ?= $(shell find . -type f -name "*.go" ! -path "./.build/*")
 GOOS   ?= $(shell uname | tr A-Z a-z)
 GOARCH ?= $(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m)))
@@ -48,6 +50,8 @@ GO_VERSION ?= 1.5.3
 GOURL      ?= https://golang.org/dl
 GOPKG      ?= go$(GO_VERSION).$(GOOS)-$(GOARCH).tar.gz
 GOPATH     := $(CURDIR)/.build/gopath
+GOFLAGS    := -ldflags "-X main.version=$(VERSION) -X main.versionGitCommit=$(GIT_COMMIT)"
+
 
 # Check for the correct version of go in the path. If we find it, use it.
 # Otherwise, prepare to build go locally.

--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -50,7 +50,7 @@ GO_VERSION ?= 1.5.3
 GOURL      ?= https://golang.org/dl
 GOPKG      ?= go$(GO_VERSION).$(GOOS)-$(GOARCH).tar.gz
 GOPATH     := $(CURDIR)/.build/gopath
-GOFLAGS    := -ldflags "-X main.version=$(VERSION) -X main.versionGitCommit=$(GIT_COMMIT)"
+GOFLAGS    := $(GOFLAGS) -ldflags "-X main.version=$(VERSION) -X main.versionGitCommit=$(GIT_COMMIT)"
 
 
 # Check for the correct version of go in the path. If we find it, use it.

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -20,7 +20,7 @@ func mongodbDefaultUri() string {
 }
 
 var (
-	version string          = "unknown"
+	version          string = "unknown"
 	versionGitCommit string = "unknown"
 
 	doPrintVersion    = flag.Bool("version", false, "Print version info and exit.")

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -100,5 +100,6 @@ func main() {
 	shared.ParseEnabledGroups(*enabledGroupsFlag)
 
 	fmt.Println("### Warning: the exporter is in beta/experimental state and field names are very\n### likely to change in the future and features may change or get removed!\n### See: https://github.com/Percona-Lab/prometheus_mongodb_exporter for updates")
+	fmt.Printf("Starting mongodb_exporter version: %s, git commit: %s\n", version, versionGitCommit)
 	startWebServer()
 }

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -20,10 +20,10 @@ func mongodbDefaultUri() string {
 }
 
 var (
-	version string = "unknown"
+	version string          = "unknown"
 	versionGitCommit string = "unknown"
 
-	printVersion      = flag.Bool("version", false, "Print version info and exit.")
+	doPrintVersion    = flag.Bool("version", false, "Print version info and exit.")
 	listenAddressFlag = flag.String("web.listen-address", ":9104", "Address on which to expose metrics and web interface.")
 	metricsPathFlag   = flag.String("web.metrics-path", "/metrics", "Path under which to expose metrics.")
 
@@ -32,6 +32,10 @@ var (
 	authUserFlag      = flag.String("auth.user", "", "Username for basic auth.")
 	authPassFlag      = flag.String("auth.pass", "", "Password for basic auth.")
 )
+
+func printVersion() {
+	fmt.Printf("mongodb_exporter version: %s, git commit hash: %s\n", version, versionGitCommit)
+}
 
 type basicAuthHandler struct {
 	handler  http.HandlerFunc
@@ -68,6 +72,7 @@ func prometheusHandler() http.Handler {
 }
 
 func startWebServer() {
+	printVersion()
 	fmt.Printf("Listening on %s\n", *listenAddressFlag)
 	handler := prometheusHandler()
 
@@ -91,15 +96,14 @@ func registerCollector() {
 func main() {
 	flag.Parse()
 
-	if *printVersion {
-		fmt.Printf("mongodb_exporter version: %s\n", version)
-		fmt.Printf("git commit hash: %s\n", versionGitCommit)
+	if *doPrintVersion {
+		printVersion()
 		os.Exit(0)
 	}
 
 	shared.ParseEnabledGroups(*enabledGroupsFlag)
 
 	fmt.Println("### Warning: the exporter is in beta/experimental state and field names are very\n### likely to change in the future and features may change or get removed!\n### See: https://github.com/Percona-Lab/prometheus_mongodb_exporter for updates")
-	fmt.Printf("Starting mongodb_exporter version: %s, git commit: %s\n", version, versionGitCommit)
+
 	startWebServer()
 }

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -91,7 +91,7 @@ func registerCollector() {
 func main() {
 	flag.Parse()
 
-	if *printVersion && version != "" && versionGitCommit != "" {
+	if *printVersion {
 		fmt.Printf("mongodb_exporter version: %s\n", version)
 		fmt.Printf("git commit hash: %s\n", versionGitCommit)
 		os.Exit(0)

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -20,6 +20,10 @@ func mongodbDefaultUri() string {
 }
 
 var (
+	version string = "unknown"
+	versionGitCommit string = "unknown"
+
+	printVersion      = flag.Bool("version", false, "Print version info and exit.")
 	listenAddressFlag = flag.String("web.listen-address", ":9104", "Address on which to expose metrics and web interface.")
 	metricsPathFlag   = flag.String("web.metrics-path", "/metrics", "Path under which to expose metrics.")
 
@@ -86,6 +90,13 @@ func registerCollector() {
 
 func main() {
 	flag.Parse()
+
+	if *printVersion && version != "" && versionGitCommit != "" {
+		fmt.Printf("mongodb_exporter version: %s\n", version)
+		fmt.Printf("git commit hash: %s\n", versionGitCommit)
+		os.Exit(0)
+	}
+
 	shared.ParseEnabledGroups(*enabledGroupsFlag)
 
 	fmt.Println("### Warning: the exporter is in beta/experimental state and field names are very\n### likely to change in the future and features may change or get removed!\n### See: https://github.com/Percona-Lab/prometheus_mongodb_exporter for updates")


### PR DESCRIPTION
Adding -version flag to mongodb_exporter.go, and flags to 'go build' step to compile the version into the binary.

Result:
`[tim@centos7 prometheus_mongodb_exporter]$ ./mongodb_exporter -version
mongodb_exporter version: 0.1.0
git commit hash: e0afdfe1af1b979fa3472e3eca38d776b27af2ce`