### PR TITLE
Process inMemory stats as WiredTiger

### DIFF
--- a/collector/mongod/server_status.go
+++ b/collector/mongod/server_status.go
@@ -61,6 +61,7 @@ type ServerStatus struct {
 
 	Cursors *Cursors `bson:"cursors"`
 
+	InMemory	*WiredTigerStats	`bson:"inMemory"`
 	RocksDb		*RocksDbStats		`bson:"rocksdb"`
 	WiredTiger	*WiredTigerStats	`bson:"wiredTiger"`
 }
@@ -115,6 +116,9 @@ func (status *ServerStatus) Export(ch chan<- prometheus.Metric) {
 	}
 	if status.Cursors != nil {
 		status.Cursors.Export(ch)
+	}
+	if status.InMemory != nil {
+		status.InMemory.Export(ch)
 	}
 	if status.RocksDb != nil {
 		status.RocksDb.Export(ch)
@@ -171,6 +175,9 @@ func (status *ServerStatus) Describe(ch chan<- *prometheus.Desc) {
 	}
 	if status.Cursors != nil {
 		status.Cursors.Describe(ch)
+	}
+	if status.InMemory != nil {
+		status.InMemory.Describe(ch)
 	}
 	if status.RocksDb != nil {
 		status.RocksDb.Describe(ch)


### PR DESCRIPTION
Process inMemory stats using the already-existing WiredTiger structs that match.

At a later time I'd like to rename the metric names to suggest the metric is for in-memory wiredtiger or not, but this was a very low-effort starting point.