### PR TITLE
Use Rocksdb Counters to fix #24

### DIFF
--- a/collector/mongod/rocksdb.go
+++ b/collector/mongod/rocksdb.go
@@ -257,12 +257,12 @@ var (
 		Name:		"compaction_avg_seconds",
 		Help:		"The average time per compaction between levels N and N+1 in RocksDB",
 	}, []string{"level"})
-	rocksDbLevel0ReadMicros = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	rocksDbReadLatencyMicros = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
-		Name:		"level0_read_latency_microseconds",
-		Help:		"The Level0 read latency in RocksDB in microseconds",
-	}, []string{"type"})
+		Name:		"read_latency_microseconds",
+		Help:		"The read latency in RocksDB in microseconds by level",
+	}, []string{"level", "type"})
 )
 
 type RocksDbStatsCounters struct {
@@ -606,7 +606,7 @@ func (stats *RocksDbStats) Describe(ch chan<- *prometheus.Desc) {
 		stats.Counters.Describe(ch)
 
 		// level0 read latency stats get added to 'stats' when in counter-mode
-		rocksDbLevel0ReadMicros.Describe(ch)
+		rocksDbReadLatencyMicros.Describe(ch)
 	}
 }
 
@@ -683,18 +683,18 @@ func (stats *RocksDbStats) Export(ch chan<- prometheus.Metric) {
 	if stats.Counters != nil {
 		stats.Counters.Export(ch)
 
-		// level0 read latency stats get added to 'stats' when in counter-mode
-		rocksDbLevel0ReadMicros.WithLabelValues("count").Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Count: ", 0))
-		rocksDbLevel0ReadMicros.WithLabelValues("avg").Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Count: ", 2))
-		rocksDbLevel0ReadMicros.WithLabelValues("stddev").Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Count: ", 4))
-		rocksDbLevel0ReadMicros.WithLabelValues("min").Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Min: ", 0))
-		rocksDbLevel0ReadMicros.WithLabelValues("median").Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Min: ", 2))
-		rocksDbLevel0ReadMicros.WithLabelValues("max").Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Min: ", 4))
-		rocksDbLevel0ReadMicros.WithLabelValues("P50").Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 1))
-		rocksDbLevel0ReadMicros.WithLabelValues("P75").Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 3))
-		rocksDbLevel0ReadMicros.WithLabelValues("P99").Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 5))
-		rocksDbLevel0ReadMicros.WithLabelValues("P99.9").Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 7))
-		rocksDbLevel0ReadMicros.WithLabelValues("P99.99").Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 9))
-		rocksDbLevel0ReadMicros.Collect(ch)
+		// read latency stats get added to 'stats' when in counter-mode
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "count"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Count: ", 0))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "avg"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Count: ", 2))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "stddev"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Count: ", 4))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "min"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Min: ", 0))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "median"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Min: ", 2))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "max"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Min: ", 4))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "P50"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 1))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "P75"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 3))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "P99"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 5))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "P99.9"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 7))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "P99.99"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 9))
+		rocksDbReadLatencyMicros.Collect(ch)
 	}
 }

--- a/collector/mongod/rocksdb.go
+++ b/collector/mongod/rocksdb.go
@@ -265,25 +265,43 @@ var (
 	}, []string{"level"})
 )
 
+type RocksDbStatsCounters struct {
+	NumKeysWritten		float64	`bson:"num-keys-written"`
+	NumKeysRead		float64	`bson:"num-keys-read"`
+	NumSeeks		float64	`bson:"num-seeks"`
+	NumForwardIter		float64	`bson:"num-forward-iterations"`	
+	NumBackwardIter		float64	`bson:"num-backward-iterations"`	
+	BlockCacheMisses	float64	`bson:"block-cache-misses"`
+	BlockCacheHits		float64	`bson:"block-cache-hits"`
+	BloomFilterUseful	float64 `bson:"bloom-filter-useful"`
+	BytesWritten		float64 `bson:"bytes-written"`
+	BytesReadPointLookup	float64	`bson:"bytes-read-point-lookup"`
+	BytesReadIteration	float64 `bson:"bytes-read-iteration"`
+	FlushBytesWritten	float64 `bson:"flush-bytes-written"`
+	CompactionBytesRead	float64	`bson:"compaction-bytes-read"`
+	CompactionBytesWritten	float64	`bson:"compaction-bytes-written"`
+}
+
 type RocksDbStats struct {
-	NumImmutableMemTable		string		`bson:"num-immutable-mem-table"`
-	MemTableFlushPending		string		`bson:"mem-table-flush-pending"`
-	CompactionPending		string		`bson:"compaction-pending"`
-	BackgroundErrors		string		`bson:"background-errors"`
-	CurSizeMemTableActive		string		`bson:"cur-size-active-mem-table"`
-	CurSizeAllMemTables		string		`bson:"cur-size-all-mem-tables"`
-	NumEntriesMemTableActive	string		`bson:"num-entries-active-mem-table"`
-	NumEntriesImmMemTables		string		`bson:"num-entries-imm-mem-tables"`
-	EstimateTableReadersMem		string		`bson:"estimate-table-readers-mem"`
-	NumSnapshots			string		`bson:"num-snapshots"`
-	OldestSnapshotTime		string		`bson:"oldest-snapshot-time"`
-	NumLiveVersions			string		`bson:"num-live-versions"`
-	BlockCacheUsage			string		`bson:"block-cache-usage"`
-	TotalLiveRecoveryUnits		float64		`bson:"total-live-recovery-units"`
-	TransactionEngineKeys		float64		`bson:"transaction-engine-keys"`
-	TransactionEngineSnapshots	float64		`bson:"transaction-engine-snapshots"`
-	Stats				[]string	`bson:"stats"`
-	ThreadStatus			[]string	`bson:"thread-status"`
+	NumImmutableMemTable		string			`bson:"num-immutable-mem-table"`
+	MemTableFlushPending		string			`bson:"mem-table-flush-pending"`
+	CompactionPending		string			`bson:"compaction-pending"`
+	BackgroundErrors		string			`bson:"background-errors"`
+	CurSizeMemTableActive		string			`bson:"cur-size-active-mem-table"`
+	CurSizeAllMemTables		string			`bson:"cur-size-all-mem-tables"`
+	NumEntriesMemTableActive	string			`bson:"num-entries-active-mem-table"`
+	NumEntriesImmMemTables		string			`bson:"num-entries-imm-mem-tables"`
+	EstimateTableReadersMem		string			`bson:"estimate-table-readers-mem"`
+	NumSnapshots			string			`bson:"num-snapshots"`
+	OldestSnapshotTime		string			`bson:"oldest-snapshot-time"`
+	NumLiveVersions			string			`bson:"num-live-versions"`
+	BlockCacheUsage			string			`bson:"block-cache-usage"`
+	TotalLiveRecoveryUnits		float64			`bson:"total-live-recovery-units"`
+	TransactionEngineKeys		float64			`bson:"transaction-engine-keys"`
+	TransactionEngineSnapshots	float64			`bson:"transaction-engine-snapshots"`
+	Stats				[]string		`bson:"stats"`
+	ThreadStatus			[]string		`bson:"thread-status"`
+	Counters			*RocksDbStatsCounters	`bson:"counters,omitempty"`
 }
 
 type RocksDbLevelStatsFiles struct {

--- a/collector/mongod/rocksdb.go
+++ b/collector/mongod/rocksdb.go
@@ -44,12 +44,18 @@ var (
 		Name:		"compactions_total",
 		Help:		"The total number of compactions between levels N and N+1 in RocksDB",
 	}, []string{"level"})
-	rocksDbBlockCache = prometheus.NewCounterVec(prometheus.CounterOpts{
+	rocksDbBlockCacheHits = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
-		Name:		"block_cache_total",
-		Help:		"The total number of RocksDB Block Cache operations",
-	}, []string{"type"})
+		Name:		"block_cache_hits_total",
+		Help:		"The total number of hits to the RocksDB Block Cache",
+	})
+	rocksDbBlockCacheMisses = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace:	Namespace,
+		Subsystem:	"rocksdb",
+		Name:		"block_cache_misses_total",
+		Help:		"The total number of misses to the RocksDB Block Cache",
+	})
 	rocksDbKeys = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
@@ -542,7 +548,8 @@ func (stats *RocksDbStats) ProcessReadLatencyStats() {
 }
 
 func (stats *RocksDbStatsCounters) Describe(ch chan<- *prometheus.Desc) {
-	rocksDbBlockCache.Describe(ch)
+	rocksDbBlockCacheHits.Describe(ch)
+	rocksDbBlockCacheMisses.Describe(ch)
 	rocksDbKeys.Describe(ch)
 	rocksDbSeeks.Describe(ch)
 	rocksDbIterations.Describe(ch)
@@ -552,8 +559,8 @@ func (stats *RocksDbStatsCounters) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (stats *RocksDbStatsCounters) Export(ch chan<- prometheus.Metric) {
-	rocksDbBlockCache.WithLabelValues("hits").Set(stats.BlockCacheHits)
-	rocksDbBlockCache.WithLabelValues("misses").Set(stats.BlockCacheMisses)
+	rocksDbBlockCacheHits.Set(stats.BlockCacheHits)
+	rocksDbBlockCacheMisses.Set(stats.BlockCacheMisses)
 	rocksDbKeys.WithLabelValues("written").Set(stats.NumKeysWritten)
 	rocksDbKeys.WithLabelValues("read").Set(stats.NumKeysRead)
 	rocksDbSeeks.Set(stats.NumSeeks)
@@ -567,7 +574,8 @@ func (stats *RocksDbStatsCounters) Export(ch chan<- prometheus.Metric) {
 	rocksDbBytesRead.WithLabelValues("iteration").Set(stats.BytesReadIteration)
 	rocksDbBytesRead.WithLabelValues("compation").Set(stats.CompactionBytesRead)
 
-	rocksDbBlockCache.Collect(ch)
+	rocksDbBlockCacheHits.Collect(ch)
+	rocksDbBlockCacheMisses.Collect(ch)
 	rocksDbKeys.Collect(ch)
 	rocksDbSeeks.Collect(ch)
 	rocksDbIterations.Collect(ch)

--- a/collector/mongod/rocksdb.go
+++ b/collector/mongod/rocksdb.go
@@ -125,18 +125,12 @@ var (
 		Name:		"memtable_bytes",
 		Help:		"The current number of MemTable bytes in RocksDB",
 	}, []string{"type"}) 
-	rocksDbNumEntriesMemTableActive = prometheus.NewGauge(prometheus.GaugeOpts{
+	rocksDbMemtableItems = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
-		Name:		"memtable_active_entries",
-		Help:		"The current number of cctive MemTable entries in RocksDB",
-	}) 
-	rocksDbNumEntriesImmMemTable = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"immutable_memtable_entries",
-		Help:		"The current number of immutable MemTable entries in RocksDB",
-	}) 
+		Name:		"memtable_entries",
+		Help:		"The current number of Memtable entries in RocksDB",
+	}, []string{"type"}) 
 	rocksDbEstimateTableReadersMem = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
@@ -602,8 +596,7 @@ func (stats *RocksDbStats) Describe(ch chan<- *prometheus.Desc) {
 	rocksDbCompactionPending.Describe(ch)
 	rocksDbBackgroundErrors.Describe(ch)
 	rocksDbMemTableBytes.Describe(ch)
-	rocksDbNumEntriesMemTableActive.Describe(ch)
-	rocksDbNumEntriesImmMemTable.Describe(ch)
+	rocksDbMemtableItems.Describe(ch)
 	rocksDbEstimateTableReadersMem.Describe(ch)
 	rocksDbNumSnapshots.Describe(ch)
 	rocksDbOldestSnapshotTimestamp.Describe(ch)
@@ -637,8 +630,8 @@ func (stats *RocksDbStats) Export(ch chan<- prometheus.Metric) {
 	rocksDbMemTableFlushPending.Set(ParseStr(stats.MemTableFlushPending))
 	rocksDbCompactionPending.Set(ParseStr(stats.CompactionPending))
 	rocksDbBackgroundErrors.Set(ParseStr(stats.BackgroundErrors))
-	rocksDbNumEntriesMemTableActive.Set(ParseStr(stats.NumEntriesMemTableActive))
-	rocksDbNumEntriesImmMemTable.Set(ParseStr(stats.NumEntriesImmMemTables))
+	rocksDbMemtableItems.WithLabelValues("active").Set(ParseStr(stats.NumEntriesMemTableActive))
+	rocksDbMemtableItems.WithLabelValues("immutable").Set(ParseStr(stats.NumEntriesImmMemTables))
 	rocksDbNumSnapshots.Set(ParseStr(stats.NumSnapshots))
 	rocksDbOldestSnapshotTimestamp.Set(ParseStr(stats.OldestSnapshotTime))
 	rocksDbNumLiveVersions.Set(ParseStr(stats.NumLiveVersions))
@@ -678,8 +671,7 @@ func (stats *RocksDbStats) Export(ch chan<- prometheus.Metric) {
 	rocksDbMemTableFlushPending.Collect(ch)
 	rocksDbCompactionPending.Collect(ch)
 	rocksDbBackgroundErrors.Collect(ch)
-	rocksDbNumEntriesMemTableActive.Collect(ch)
-	rocksDbNumEntriesImmMemTable.Collect(ch)
+	rocksDbMemtableItems.Collect(ch)
 	rocksDbNumSnapshots.Collect(ch)
 	rocksDbOldestSnapshotTimestamp.Collect(ch)
 	rocksDbNumLiveVersions.Collect(ch)

--- a/collector/mongod/rocksdb.go
+++ b/collector/mongod/rocksdb.go
@@ -532,6 +532,26 @@ func (stats *RocksDbStats) ProcessStalls() {
 	}
 }
 
+func (stats *RocksDbStats) ProcessReadLatencyStats() {
+	for _, level_num := range []string{"0", "1", "2", "3", "4", "5", "6"} {
+		section := "** Level "+level_num+" read latency histogram (micros):"
+		if len(stats.GetStatsSection(section)) > 0 {
+			level := "L"+level_num
+			rocksDbReadLatencyMicros.With(prometheus.Labels{"level": level, "type": "count"}).Set(stats.GetStatsLineField(section, "Count: ", 0))
+			rocksDbReadLatencyMicros.With(prometheus.Labels{"level": level, "type": "avg"}).Set(stats.GetStatsLineField(section, "Count: ", 2))
+			rocksDbReadLatencyMicros.With(prometheus.Labels{"level": level, "type": "stddev"}).Set(stats.GetStatsLineField(section, "Count: ", 4))
+			rocksDbReadLatencyMicros.With(prometheus.Labels{"level": level, "type": "min"}).Set(stats.GetStatsLineField(section, "Min: ", 0))
+			rocksDbReadLatencyMicros.With(prometheus.Labels{"level": level, "type": "median"}).Set(stats.GetStatsLineField(section, "Min: ", 2))
+			rocksDbReadLatencyMicros.With(prometheus.Labels{"level": level, "type": "max"}).Set(stats.GetStatsLineField(section, "Min: ", 4))
+			rocksDbReadLatencyMicros.With(prometheus.Labels{"level": level, "type": "P50"}).Set(stats.GetStatsLineField(section, "Percentiles: ", 1))
+			rocksDbReadLatencyMicros.With(prometheus.Labels{"level": level, "type": "P75"}).Set(stats.GetStatsLineField(section, "Percentiles: ", 3))
+			rocksDbReadLatencyMicros.With(prometheus.Labels{"level": level, "type": "P99"}).Set(stats.GetStatsLineField(section, "Percentiles: ", 5))
+			rocksDbReadLatencyMicros.With(prometheus.Labels{"level": level, "type": "P99.9"}).Set(stats.GetStatsLineField(section, "Percentiles: ", 7))
+			rocksDbReadLatencyMicros.With(prometheus.Labels{"level": level, "type": "P99.99"}).Set(stats.GetStatsLineField(section, "Percentiles: ", 9))
+		}
+	}
+}
+
 func (stats *RocksDbStatsCounters) Describe(ch chan<- *prometheus.Desc) {
 	rocksDbBlockCache.Describe(ch)
 	rocksDbKeys.Describe(ch)
@@ -684,17 +704,7 @@ func (stats *RocksDbStats) Export(ch chan<- prometheus.Metric) {
 		stats.Counters.Export(ch)
 
 		// read latency stats get added to 'stats' when in counter-mode
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "count"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Count: ", 0))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "avg"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Count: ", 2))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "stddev"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Count: ", 4))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "min"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Min: ", 0))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "median"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Min: ", 2))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "max"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Min: ", 4))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "P50"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 1))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "P75"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 3))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "P99"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 5))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "P99.9"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 7))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "P99.99"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 9))
+		stats.ProcessReadLatencyStats()
 		rocksDbReadLatencyMicros.Collect(ch)
 	}
 }

--- a/collector/mongod/rocksdb.go
+++ b/collector/mongod/rocksdb.go
@@ -370,7 +370,7 @@ func ParseStr(str string) float64 {
 		}
 	} else if strings.HasSuffix(str, "B") {
 		str_remove = "B"
-	} else if strings.Count(str, ":") == 2 {
+	} else if strings.HasSuffix(str, "H:M:S") {
 		return ParseTime(str)
 	}
 
@@ -463,8 +463,11 @@ func (stats *RocksDbStats) GetStatsLine(section_prefix string, line_prefix strin
 	for _, line := range stats.GetStatsSection(section_prefix) {
 		if strings.HasPrefix(line, line_prefix) {
 			line = strings.Replace(line, line_prefix, "", 1)
-			line = strings.Replace(line, ", ", " ", -1)
-			fields = SplitByWs(line)
+			if strings.Contains(line, ", ") {
+				fields = strings.Split(line, ", ")
+			} else {
+				fields = SplitByWs(line)
+			}
 		}
 	}
 	return fields
@@ -633,11 +636,11 @@ func (stats *RocksDbStats) Describe(ch chan<- *prometheus.Desc) {
 func (stats *RocksDbStats) Export(ch chan<- prometheus.Metric) {
 	// cumulative stats from db.serverStatus().rocksdb.stats (parsed):
 	rocksDbWritesPerBatch.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative writes: ", 4))
-	rocksDbWritesPerSec.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative writes: ", 6))
+	rocksDbWritesPerSec.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative writes: ", 5))
 	rocksDbWALBytesPerSecs.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative WAL: ", 4))
 	rocksDbWALWritesPerSync.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative WAL: ", 2))
 	rocksDbStalledSecs.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative stall: ", 0))
-	rocksDbStallPercent.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative stall: ", 2))
+	rocksDbStallPercent.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative stall: ", 1))
 
 	// stats from db.serverStatus().rocksdb (parsed):
 	rocksDbNumImmutableMemTable.Set(ParseStr(stats.NumImmutableMemTable))

--- a/collector/mongod/rocksdb.go
+++ b/collector/mongod/rocksdb.go
@@ -362,14 +362,6 @@ func ParseStr(str string) float64 {
 	} else if strings.Contains(str, " PB") || strings.HasSuffix(str, "PB") {
 		multiply = petabyte
 		str_remove = "PB"
-	} else if strings.Contains(str, "K") {
-		first_field := strings.Split(str, " ")[0]
-		if strings.HasSuffix(first_field, "K") {
-			multiply = 1000
-			str_remove = "K"
-		}
-	} else if strings.HasSuffix(str, "B") {
-		str_remove = "B"
 	} else if strings.HasSuffix(str, "H:M:S") {
 		return ParseTime(str)
 	}
@@ -537,9 +529,9 @@ func (stats *RocksDbStats) ProcessStalls() {
 
 func (stats *RocksDbStats) ProcessReadLatencyStats() {
 	for _, level_num := range []string{"0", "1", "2", "3", "4", "5", "6"} {
+		level := "L"+level_num
 		section := "** Level "+level_num+" read latency histogram (micros):"
 		if len(stats.GetStatsSection(section)) > 0 {
-			level := "L"+level_num
 			rocksDbReadLatencyMicros.With(prometheus.Labels{"level": level, "type": "count"}).Set(stats.GetStatsLineField(section, "Count: ", 0))
 			rocksDbReadLatencyMicros.With(prometheus.Labels{"level": level, "type": "avg"}).Set(stats.GetStatsLineField(section, "Count: ", 2))
 			rocksDbReadLatencyMicros.With(prometheus.Labels{"level": level, "type": "stddev"}).Set(stats.GetStatsLineField(section, "Count: ", 4))

--- a/collector/mongod/rocksdb.go
+++ b/collector/mongod/rocksdb.go
@@ -14,48 +14,6 @@ var (
 	terabyte float64 = gigabyte * 1024
 	petabyte float64 = terabyte * 1024
 
-	rocksDbWriteOps = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"writes_total",
-		Help:		"The total number of write operations in RocksDB",
-	})
-	rocksDbWriteKeys = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"writes_key_total",
-		Help:		"The total number of key write operations in RocksDB",
-	})
-	rocksDbWriteBatches = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"write_batches_total",
-		Help:		"The total number of write batches in RocksDB",
-	})
-	rocksDbWriteBytes = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"write_bytes_total",
-		Help:		"The total number of data written by RocksDB",
-	})
-	rocksDbFlushedBytes = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"flushed_bytes_total",
-		Help:		"The total number of flushed bytes in RocksDB",
-	})
-	rocksDbWALOperations = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"write_ahead_log_operations_total",
-		Help:		"The total number of Write-Ahead-Log operations in RocksDB",
-	}, []string{"type"})
-	rocksDbWALBytes = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"write_ahead_log_bytes_total",
-		Help:		"The total number of Write-Ahead-Log syncs in RocksDB",
-	})
 	rocksDbStalledSecs = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
@@ -610,15 +568,8 @@ func (stats *RocksDbStatsCounters) Export(ch chan<- prometheus.Metric) {
 }
 
 func (stats *RocksDbStats) Describe(ch chan<- *prometheus.Desc) {
-	rocksDbWriteOps.Describe(ch)
-	rocksDbWriteKeys.Describe(ch)
-	rocksDbWriteBatches.Describe(ch)
-	rocksDbWriteBytes.Describe(ch)
 	rocksDbWritesPerBatch.Describe(ch)
 	rocksDbWritesPerSec.Describe(ch)
-	rocksDbFlushedBytes.Describe(ch)
-	rocksDbWALOperations.Describe(ch)
-	rocksDbWALBytes.Describe(ch)
 	rocksDbWALBytesPerSecs.Describe(ch)
 	rocksDbWALWritesPerSync.Describe(ch)
 	rocksDbStallPercent.Describe(ch)
@@ -659,16 +610,8 @@ func (stats *RocksDbStats) Describe(ch chan<- *prometheus.Desc) {
 
 func (stats *RocksDbStats) Export(ch chan<- prometheus.Metric) {
 	// cumulative stats from db.serverStatus().rocksdb.stats (parsed):
-	rocksDbFlushedBytes.Set(stats.GetStatsLineField("** Compaction Stats [default] **", "Flush(GB): ", 0) * gigabyte)
-	rocksDbWriteOps.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative writes: ", 0))
-	rocksDbWriteKeys.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative writes: ", 1))
-	rocksDbWriteBatches.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative writes: ", 2))
 	rocksDbWritesPerBatch.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative writes: ", 3))
-	rocksDbWriteBytes.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative writes: ", 4))
 	rocksDbWritesPerSec.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative writes: ", 5))
-	rocksDbWALOperations.WithLabelValues("write").Set(stats.GetStatsLineField("** DB Stats **", "Cumulative WAL: ", 0))
-	rocksDbWALOperations.WithLabelValues("sync").Set(stats.GetStatsLineField("** DB Stats **", "Cumulative WAL: ", 1))
-	rocksDbWALBytes.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative WAL: ", 3))
 	rocksDbWALBytesPerSecs.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative WAL: ", 4))
 	rocksDbWALWritesPerSync.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative WAL: ", 2))
 	rocksDbStalledSecs.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative stall: ", 0))
@@ -701,15 +644,8 @@ func (stats *RocksDbStats) Export(ch chan<- prometheus.Metric) {
 	// process stall counts into a vector:
 	stats.ProcessStalls()
 
-	rocksDbWriteOps.Collect(ch)
-	rocksDbWriteKeys.Collect(ch)
-	rocksDbWriteBatches.Collect(ch)
-	rocksDbWriteBytes.Collect(ch)
 	rocksDbWritesPerBatch.Collect(ch)
 	rocksDbWritesPerSec.Collect(ch)
-	rocksDbFlushedBytes.Collect(ch)
-	rocksDbWALOperations.Collect(ch)
-	rocksDbWALBytes.Collect(ch)
 	rocksDbWALBytesPerSecs.Collect(ch)
 	rocksDbWALWritesPerSync.Collect(ch)
 	rocksDbStallPercent.Collect(ch)
@@ -719,7 +655,6 @@ func (stats *RocksDbStats) Export(ch chan<- prometheus.Metric) {
 	rocksDbCompactionThreads.Collect(ch)
 	rocksDbLevelSizeBytes.Collect(ch)
 	rocksDbLevelScore.Collect(ch)
-	rocksDbCompactionBytes.Collect(ch)
 	rocksDbCompactionBytesPerSec.Collect(ch)
 	rocksDbCompactionWriteAmplification.Collect(ch)
 	rocksDbCompactionSecondsTotal.Collect(ch)

--- a/collector/mongod/rocksdb.go
+++ b/collector/mongod/rocksdb.go
@@ -125,7 +125,7 @@ var (
 		Name:		"memtable_bytes",
 		Help:		"The current number of MemTable bytes in RocksDB",
 	}, []string{"type"}) 
-	rocksDbMemtableItems = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	rocksDbMemtableEntries = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
 		Name:		"memtable_entries",
@@ -596,7 +596,7 @@ func (stats *RocksDbStats) Describe(ch chan<- *prometheus.Desc) {
 	rocksDbCompactionPending.Describe(ch)
 	rocksDbBackgroundErrors.Describe(ch)
 	rocksDbMemTableBytes.Describe(ch)
-	rocksDbMemtableItems.Describe(ch)
+	rocksDbMemtableEntries.Describe(ch)
 	rocksDbEstimateTableReadersMem.Describe(ch)
 	rocksDbNumSnapshots.Describe(ch)
 	rocksDbOldestSnapshotTimestamp.Describe(ch)
@@ -630,8 +630,8 @@ func (stats *RocksDbStats) Export(ch chan<- prometheus.Metric) {
 	rocksDbMemTableFlushPending.Set(ParseStr(stats.MemTableFlushPending))
 	rocksDbCompactionPending.Set(ParseStr(stats.CompactionPending))
 	rocksDbBackgroundErrors.Set(ParseStr(stats.BackgroundErrors))
-	rocksDbMemtableItems.WithLabelValues("active").Set(ParseStr(stats.NumEntriesMemTableActive))
-	rocksDbMemtableItems.WithLabelValues("immutable").Set(ParseStr(stats.NumEntriesImmMemTables))
+	rocksDbMemtableEntries.WithLabelValues("active").Set(ParseStr(stats.NumEntriesMemTableActive))
+	rocksDbMemtableEntries.WithLabelValues("immutable").Set(ParseStr(stats.NumEntriesImmMemTables))
 	rocksDbNumSnapshots.Set(ParseStr(stats.NumSnapshots))
 	rocksDbOldestSnapshotTimestamp.Set(ParseStr(stats.OldestSnapshotTime))
 	rocksDbNumLiveVersions.Set(ParseStr(stats.NumLiveVersions))
@@ -671,7 +671,7 @@ func (stats *RocksDbStats) Export(ch chan<- prometheus.Metric) {
 	rocksDbMemTableFlushPending.Collect(ch)
 	rocksDbCompactionPending.Collect(ch)
 	rocksDbBackgroundErrors.Collect(ch)
-	rocksDbMemtableItems.Collect(ch)
+	rocksDbMemtableEntries.Collect(ch)
 	rocksDbNumSnapshots.Collect(ch)
 	rocksDbOldestSnapshotTimestamp.Collect(ch)
 	rocksDbNumLiveVersions.Collect(ch)

--- a/collector/mongod/rocksdb.go
+++ b/collector/mongod/rocksdb.go
@@ -356,6 +356,8 @@ func ParseStr(str string) float64 {
 	} else if strings.Contains(str, " PB") || strings.HasSuffix(str, "PB") {
 		multiply = petabyte
 		str_remove = "PB"
+	} else if strings.Contains(str, " B") || strings.HasSuffix(str, "B") {
+		str_remove = "B"
 	} else if strings.HasSuffix(str, "H:M:S") {
 		return ParseTime(str)
 	}
@@ -637,7 +639,6 @@ func (stats *RocksDbStats) Export(ch chan<- prometheus.Metric) {
 	rocksDbNumLiveVersions.Set(ParseStr(stats.NumLiveVersions))
 	rocksDbBlockCacheUsage.Set(ParseStr(stats.BlockCacheUsage))
 	rocksDbEstimateTableReadersMem.Set(ParseStr(stats.EstimateTableReadersMem))
-	rocksDbBlockCacheUsage.Set(ParseStr(stats.BlockCacheUsage))
 	rocksDbMemTableBytes.WithLabelValues("active").Set(ParseStr(stats.CurSizeMemTableActive))
 	rocksDbMemTableBytes.WithLabelValues("total").Set(ParseStr(stats.CurSizeAllMemTables))
 

--- a/collector/mongod/rocksdb.go
+++ b/collector/mongod/rocksdb.go
@@ -605,7 +605,7 @@ func (stats *RocksDbStats) Describe(ch chan<- *prometheus.Desc) {
 	if stats.Counters != nil {
 		stats.Counters.Describe(ch)
 
-		// level0 read latency stats get added to 'stats' when in counter-mode
+		// read latency stats get added to 'stats' when in counter-mode
 		rocksDbReadLatencyMicros.Describe(ch)
 	}
 }

--- a/collector/mongod/rocksdb.go
+++ b/collector/mongod/rocksdb.go
@@ -254,7 +254,7 @@ var (
 	rocksDbCompactionAvgSeconds = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
-		Name:		"compaction_avg_seconds",
+		Name:		"compaction_average_seconds",
 		Help:		"The average time per compaction between levels N and N+1 in RocksDB",
 	}, []string{"level"})
 	rocksDbReadLatencyMicros = prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/collector/mongod/rocksdb.go
+++ b/collector/mongod/rocksdb.go
@@ -684,17 +684,17 @@ func (stats *RocksDbStats) Export(ch chan<- prometheus.Metric) {
 		stats.Counters.Export(ch)
 
 		// read latency stats get added to 'stats' when in counter-mode
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "count"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Count: ", 0))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "avg"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Count: ", 2))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "stddev"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Count: ", 4))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "min"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Min: ", 0))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "median"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Min: ", 2))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "max"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Min: ", 4))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "P50"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 1))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "P75"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 3))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "P99"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 5))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "P99.9"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 7))
-		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "level0", "type": "P99.99"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 9))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "count"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Count: ", 0))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "avg"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Count: ", 2))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "stddev"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Count: ", 4))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "min"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Min: ", 0))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "median"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Min: ", 2))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "max"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Min: ", 4))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "P50"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 1))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "P75"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 3))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "P99"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 5))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "P99.9"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 7))
+		rocksDbReadLatencyMicros.With(prometheus.Labels{"level": "L0", "type": "P99.99"}).Set(stats.GetStatsLineField("** Level 0 read latency histogram (micros):", "Percentiles: ", 9))
 		rocksDbReadLatencyMicros.Collect(ch)
 	}
 }


### PR DESCRIPTION
To fix #24, this moves to using the optional RocksDB 'counters' Igor Canadi from mongorocks recommended, enabled by the flag '--rocksdbCounters 1' or in the mongod.conf.

Moving to the 'counters' caused some new metrics to be available (mostly read latency and block cache hit/miss). Some metrics not available in 'counters' (but were in the human-readable output) are requested for addition in https://github.com/mongodb-partners/mongo-rocks/issues/34.

A PR in the https://github.com/Percona-Lab/grafana_mongodb_dashboards project is upcoming for this change.
