### PR TITLE
Fixes to improve replication lag accuracy

### DIFF
--- a/collector/mongod/replset_status.go
+++ b/collector/mongod/replset_status.go
@@ -17,7 +17,7 @@ var (
 		Subsystem: subsystem,
 		Name:      "my_name",
 		Help:      "The replica state name of the current member",
-	}, []string{"name","set"})
+	}, []string{"name", "set"})
 	myState   = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,

--- a/collector/mongod/replset_status.go
+++ b/collector/mongod/replset_status.go
@@ -17,7 +17,7 @@ var (
 		Subsystem: subsystem,
 		Name:      "my_name",
 		Help:      "The replica state name of the current member",
-	}, []string{"name", "set"})
+	}, []string{"set", "name"})
 	myState   = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,

--- a/collector/mongod/replset_status.go
+++ b/collector/mongod/replset_status.go
@@ -58,7 +58,7 @@ var (
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_optime_date",
-		Help:      "The last entry from the oplog that this member applied.",
+		Help:      "The timestamp of the last oplog entry that this member applied.",
 	}, []string{"set", "self", "name", "state"})
 	memberElectionDate = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,

--- a/collector/mongod/replset_status.go
+++ b/collector/mongod/replset_status.go
@@ -17,7 +17,7 @@ var (
 		Subsystem: subsystem,
 		Name:      "my_name",
 		Help:      "The replica state name of the current member",
-	}, []string{"name"})
+	}, []string{"name","set"})
 	myState   = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
@@ -166,7 +166,11 @@ func (replStatus *ReplSetStatus) Export(ch chan<- prometheus.Metric) {
 
 	for _, member := range replStatus.Members {
 		if member.Self != nil {
-			myName.WithLabelValues(member.Name).Set(1)
+			labels := prometheus.Labels{
+				"set":  replStatus.Set,
+				"name": member.Name,
+			}
+			myName.With(labels).Set(1)
 		}
 		ls := prometheus.Labels{
 			"set":   replStatus.Set,


### PR DESCRIPTION
1. Reset metric vectors before setting them to clear stale replset states (ie: only display current replication state). PR #17 partially duplicates this change.
2. Add new metric: 'mongodb_mongod_replset_my_name' to show the 'name' of the replica set member. This will be used to join on the member_optime_date metric to select a more accurate metric for lag.

Example output post-change:
```
$ curl -s http://localhost:9104/metrics|grep replset_my_name
# HELP mongodb_mongod_replset_my_name The replica state name of the current member
# TYPE mongodb_mongod_replset_my_name gauge
mongodb_mongod_replset_my_name{name="localhost:27017",set="test1"} 1
```