### PR TITLE
Added http basic auth and https/tls support.

### DIFF
--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/Percona-Lab/prometheus_mongodb_exporter/shared"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/yaml.v2"
 )
 
 func mongodbDefaultUri() string {
@@ -27,6 +29,7 @@ var (
 	doPrintVersion    = flag.Bool("version", false, "Print version info and exit.")
 	listenAddressFlag = flag.String("web.listen-address", ":9104", "Address on which to expose metrics and web interface.")
 	metricsPathFlag   = flag.String("web.metrics-path", "/metrics", "Path under which to expose metrics.")
+	webAuthFile       = flag.String("web.auth-file", "", "Path to YAML file with server_user, server_password options for http basic auth (overrides HTTP_AUTH env var).")
 
 	mongodbURIFlag    = flag.String("mongodb.uri", mongodbDefaultUri(), "Mongodb URI, format: [mongodb://][user:pass@]host1[:port1][,host2[:port2],...][/database][?options]")
 	enabledGroupsFlag = flag.String("groups.enabled", "asserts,durability,background_flushing,connections,extra_info,global_lock,index_counters,network,op_counters,op_counters_repl,memory,locks,metrics", "Comma-separated list of groups to use, for more info see: docs.mongodb.org/manual/reference/command/serverStatus/")
@@ -34,6 +37,11 @@ var (
 
 func printVersion() {
 	fmt.Printf("mongodb_exporter version: %s, git commit hash: %s\n", version, versionGitCommit)
+}
+
+type webAuth struct {
+	User     string `yaml:"server_user,omitempty"`
+	Password string `yaml:"server_password,omitempty"`
 }
 
 type basicAuthHandler struct {
@@ -54,25 +62,29 @@ func (h *basicAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func prometheusHandler() http.Handler {
-	var authUser, authPass string
+	cfg := &webAuth{}
 	httpAuth := os.Getenv("HTTP_AUTH")
-	if httpAuth != "" {
+	if *webAuthFile != "" {
+		bytes, err := ioutil.ReadFile(*webAuthFile)
+		if err != nil {
+			panic(fmt.Sprintf("Cannot read auth file: %s", err))
+		}
+		if err := yaml.Unmarshal(bytes, cfg); err != nil {
+			panic(fmt.Sprintf("Cannot parse auth file: %s", err))
+		}
+	} else if httpAuth != "" {
 		data := strings.SplitN(httpAuth, ":", 2)
 		if len(data) != 2 || data[0] == "" || data[1] == "" {
 			panic("HTTP_AUTH should be formatted as user:password")
 		}
-		authUser = data[0]
-		authPass = data[1]
-		fmt.Println("HTTP basic authentication is enabled")
+		cfg.User = data[0]
+		cfg.Password = data[1]
 	}
 
 	handler := prometheus.Handler()
-	if authUser != "" &&  authPass != "" {
-		handler = &basicAuthHandler{
-			handler:  handler.ServeHTTP,
-			user:     authUser,
-			password: authPass,
-		}
+	if cfg.User != "" && cfg.Password != "" {
+		handler = &basicAuthHandler{handler: handler.ServeHTTP, user: cfg.User, password: cfg.Password}
+		fmt.Println("HTTP basic authentication is enabled")
 	}
 
 	return handler

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -30,10 +31,21 @@ var (
 	listenAddressFlag = flag.String("web.listen-address", ":9104", "Address on which to expose metrics and web interface.")
 	metricsPathFlag   = flag.String("web.metrics-path", "/metrics", "Path under which to expose metrics.")
 	webAuthFile       = flag.String("web.auth-file", "", "Path to YAML file with server_user, server_password options for http basic auth (overrides HTTP_AUTH env var).")
+	sslCertFile       = flag.String("web.ssl-cert-file", "", "Path to SSL certificate file.")
+	sslKeyFile        = flag.String("web.ssl-key-file", "", "Path to SSL key file.")
 
 	mongodbURIFlag    = flag.String("mongodb.uri", mongodbDefaultUri(), "Mongodb URI, format: [mongodb://][user:pass@]host1[:port1][,host2[:port2],...][/database][?options]")
 	enabledGroupsFlag = flag.String("groups.enabled", "asserts,durability,background_flushing,connections,extra_info,global_lock,index_counters,network,op_counters,op_counters_repl,memory,locks,metrics", "Comma-separated list of groups to use, for more info see: docs.mongodb.org/manual/reference/command/serverStatus/")
 )
+
+var landingPage = []byte(`<html>
+<head><title>MongoDB exporter</title></head>
+<body>
+<h1>MongoDB exporter</h1>
+<p><a href='` + *metricsPathFlag + `'>Metrics</a></p>
+</body>
+</html>
+`)
 
 func printVersion() {
 	fmt.Printf("mongodb_exporter version: %s, git commit hash: %s\n", version, versionGitCommit)
@@ -102,12 +114,55 @@ func startWebServer() {
 
 	registerCollector()
 
-	http.Handle(*metricsPathFlag, handler)
-	fmt.Printf("Listening on %s\n", *listenAddressFlag)
-	err := http.ListenAndServe(*listenAddressFlag, nil)
+	if *sslCertFile != "" && *sslKeyFile == "" || *sslCertFile == "" && *sslKeyFile != "" {
+		panic("One of the flags -web.ssl-cert or -web.ssl-key is missed to enable HTTPS/TLS")
+	}
+	ssl := false
+	if *sslCertFile != "" && *sslKeyFile != "" {
+		if _, err := os.Stat(*sslCertFile); os.IsNotExist(err) {
+			panic(fmt.Sprintf("SSL certificate file does not exist: %s", *sslCertFile))
+		}
+		if _, err := os.Stat(*sslKeyFile); os.IsNotExist(err) {
+			panic(fmt.Sprintf("SSL key file does not exist: %s", *sslKeyFile))
+		}
+		ssl = true
+		fmt.Println("HTTPS/TLS is enabled")
+	}
 
-	if err != nil {
-		panic(err)
+	fmt.Printf("Listening on %s\n", *listenAddressFlag)
+	if ssl {
+		// https
+		mux := http.NewServeMux()
+		mux.Handle(*metricsPathFlag, handler)
+		mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Add("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
+			w.Write(landingPage)
+		})
+		tlsCfg := &tls.Config{
+			MinVersion:               tls.VersionTLS12,
+			CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
+			PreferServerCipherSuites: true,
+			CipherSuites: []uint16{
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+				tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+			},
+		}
+		srv := &http.Server{
+			Addr:         *listenAddressFlag,
+			Handler:      mux,
+			TLSConfig:    tlsCfg,
+			TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),
+		}
+		panic(srv.ListenAndServeTLS(*sslCertFile, *sslKeyFile))
+	} else {
+		// http
+		http.Handle(*metricsPathFlag, handler)
+		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			w.Write(landingPage)
+		})
+		panic(http.ListenAndServe(*listenAddressFlag, nil))
 	}
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -85,6 +85,12 @@
 			"path": "gopkg.in/mgo.v2/internal/scram",
 			"revision": "b6e2fa371e64216a45e61072a96d4e3859f169da",
 			"revisionTime": "2016-02-23T13:38:14Z"
+		},
+		{
+			"checksumSHA1": "Ww6wiSKdA8LwxoJz4DNUF+crH4g=",
+			"path": "gopkg.in/yaml.v2",
+			"revision": "f7716cbe52baa25d2e9b0d0da546fcf909fc16b4",
+			"revisionTime": "2015-12-01T16:27:45Z"
 		}
 	],
 	"rootPath": "github.com/Percona-Lab/prometheus_mongodb_exporter"


### PR DESCRIPTION
* Added `-web.auth-file` flag to alternatively support setting up http basic auth using config file. In our case, for PMM.
* Added HTTPS/TLS support.